### PR TITLE
Bump ember-rfc176-data to ^0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "qunitjs": "^2.3.3"
   },
   "dependencies": {
-    "ember-rfc176-data": "^0.1.0"
+    "ember-rfc176-data": "^0.2.0"
   },
   "directories": {
     "test": "tests"


### PR DESCRIPTION
This is needed to get the new `isEqual` and `merge` imports