### PR TITLE
Make the plugin `@ember/string` aware

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ module.exports = function(babel) {
     visitor: {
       ImportDeclaration(path, state) {
         let blacklist = (state.opts && state.opts.blacklist) || [];
-        let polyfillEmberString = state.opts.polyfillEmberString || true;
+        let polyfillEmberString = state.opts.polyfillEmberString === undefined ? true : state.opts.polyfillEmberString
         let node = path.node;
         let replacements = [];
         let removals = [];

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ module.exports = function(babel) {
     visitor: {
       ImportDeclaration(path, state) {
         let blacklist = (state.opts && state.opts.blacklist) || [];
-        let polyfillEmberString = state.opts.polyfillEmberString === undefined ? true : state.opts.polyfillEmberString
+        let polyfillEmberString = state.opts.polyfillEmberString === undefined ? true : state.opts.polyfillEmberString;
         let node = path.node;
         let replacements = [];
         let removals = [];

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,7 @@ module.exports = function(babel) {
     visitor: {
       ImportDeclaration(path, state) {
         let blacklist = (state.opts && state.opts.blacklist) || [];
+        let polyfillEmberString = state.opts.polyfillEmberString || true;
         let node = path.node;
         let replacements = [];
         let removals = [];
@@ -47,6 +48,12 @@ module.exports = function(babel) {
         if (!reverseMapping[importPath]) {
           // not a module provided by emberjs/rfcs#176
           // so we have nothing to do here
+          return;
+        }
+
+        if (!polyfillEmberString && importPath === '@ember/string') {
+          // `@ember/string` is present in the project
+          // so imports should not be transformed
           return;
         }
 


### PR DESCRIPTION
If the `@ember/string` package is available, the plugin should not convert those imports back to globals, as the modules will actually be provided by the already mentioned package instead.