### PR TITLE
Add transpile support for 'ember' module

### DIFF
--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -129,3 +129,19 @@ describe('options', () => {
     assert.equal(actual, `var assert = Ember.assert;\nvar inspect = Ember.inspect;`);
   });
 });
+
+describe(`import from 'ember'`, () => {
+  matches(
+    `import Ember from 'ember';`,
+    ``
+  );
+  matches(
+    `import Em from 'ember';`,
+    `var Em = Ember;`
+  );
+  matches(
+    `import Asdf from 'ember';`,
+    `var Asdf = Ember;`
+  );
+});
+


### PR DESCRIPTION
In today's Ember apps, `import Ember from 'ember'` is provided by ember-cli-shims. We'd like that package to no longer be required since it adds size to the runtime payload and is basically no longer required.

So move support for `import XXX from 'ember'` here.

/cc @rwjblue 