### PR TITLE
Reverts polyfillEmberString option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,6 @@ module.exports = function(babel) {
     visitor: {
       ImportDeclaration(path, state) {
         let blacklist = (state.opts && state.opts.blacklist) || [];
-        let polyfillEmberString = state.opts.polyfillEmberString === undefined ? true : state.opts.polyfillEmberString;
         let node = path.node;
         let replacements = [];
         let removals = [];
@@ -70,12 +69,6 @@ module.exports = function(babel) {
             );
           }
           removals.push(specifierPath);
-        }
-
-        if (!polyfillEmberString && importPath === '@ember/string') {
-          // `@ember/string` is present in the project
-          // so imports should not be transformed
-          return;
         }
 
         // This is the mapping to use for the import statement

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -130,26 +130,6 @@ describe('options', () => {
       assert.equal(actual, `var assert = Ember.assert;\nvar inspect = Ember.inspect;`);
     });
   });
-
-  describe('polyfillEmberString', () => {
-    it('converts `@ember/string` by default', assert => {
-      let input = `import { dasherize } from '@ember/string';`;
-      let actual = transform(input, [
-        [Plugin],
-      ]);
-
-      assert.equal(actual, `var dasherize = Ember.String.dasherize;`);
-    });
-
-    it('allows not polyfilling `@ember/string`', assert => {
-      let input = `import { dasherize } from '@ember/string';`;
-      let actual = transform(input, [
-        [Plugin, { polyfillEmberString: false }],
-      ]);
-
-      assert.equal(actual, input);
-    });
-  });
 });
 
 describe(`import from 'ember'`, () => {


### PR DESCRIPTION
We decided to use the existing blacklist mechanism to address the
`@ember/string` situation.
This way, `ember-cli-babel` will be responsible to blacklist the
relevant modules if the package is present.