### PR TITLE
Bump ember-rfc176-data to 0.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "qunitjs": "^2.3.3"
   },
   "dependencies": {
-    "ember-rfc176-data": "^0.2.0"
+    "ember-rfc176-data": "^0.2.7"
   },
   "directories": {
     "test": "tests"


### PR DESCRIPTION
Lots of missing APIs have been added to ember-rfc176-data since 0.2.0. The lack of these was causing errors for those of us with locked dependancies (e.g. yarn) so the minimum required version should probably be updated.