### PR TITLE
 Allow `export { computed } from '@ember/object'` to work

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -134,6 +134,19 @@ module.exports = function(babel) {
           path.insertAfter(replacements);
         }
       },
+
+      ExportAllDeclaration(path) {
+        let node = path.node;
+        let importPath = node.source.value;
+
+        // This is the mapping to use for the import statement
+        const mapping = reverseMapping[importPath];
+
+        // Only walk specifiers if this is a module we have a mapping for
+        if (mapping) {
+          throw path.buildCodeFrameError(`Wildcard exports from ${importPath} are currently not possible`);
+        }
+      },
     },
   };
 };

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -87,6 +87,44 @@ describe(`ember-modules-api-polyfill-default-as-alias`, () => {
   );
 });
 
+// Ensure reexporting things works
+describe(`ember-modules-api-polyfill-reexport`, () => {
+  matches(
+    `export { default as Component } from '@ember/component';`,
+    `export var Component = Ember.Component;`
+  );
+
+  matches(
+    `export { computed } from '@ember/object';`,
+    `export var computed = Ember.computed;`
+  );
+
+  matches(
+    `export { computed as foo } from '@ember/object';`,
+    `export var foo = Ember.computed;`
+  );
+
+  matches(
+    `export var foo = 42;`,
+    `export var foo = 42;`
+  );
+
+  it(`throws an error for wildcard exports`, assert => {
+    let input = `export * from '@ember/object/computed';`;
+
+    assert.throws(() => {
+      transform(input, [
+        [Plugin],
+      ]);
+    }, /Wildcard exports from @ember\/object\/computed are currently not possible/);
+  });
+
+  matches(
+    `export * from 'foo';`,
+    `export * from 'foo';`
+  );
+});
+
 // Ensure unknown exports are not removed
 describe(`unknown imports from known module`, () => {
   it(`allows blacklisting import paths`, assert => {


### PR DESCRIPTION
Resolves https://github.com/ember-cli/babel-plugin-ember-modules-api-polyfill/issues/14