### PR TITLE
Fix reexporting `default`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -187,19 +187,26 @@ module.exports = function(babel) {
 
             removals.push(specifierPath);
 
-            // Repalce the node with a new `var name = Ember.something`
-            replacements.push(
-              t.exportNamedDeclaration(
+            let declaration;
+            const memberExpression = t.memberExpression(t.identifier('Ember'), t.identifier(global));
+            if (exported.name === 'default') {
+              declaration = t.exportDefaultDeclaration(
+                memberExpression
+              );
+            } else {
+              // Replace the node with a new `var name = Ember.something`
+              declaration = t.exportNamedDeclaration(
                 t.variableDeclaration('var', [
                   t.variableDeclarator(
                     exported,
-                    t.memberExpression(t.identifier('Ember'), t.identifier(global))
+                    memberExpression
                   ),
                 ]),
                 [],
                 null
-              )
-            );
+              );
+            }
+            replacements.push(declaration);
 
           });
         }

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -90,6 +90,11 @@ describe(`ember-modules-api-polyfill-default-as-alias`, () => {
 // Ensure reexporting things works
 describe(`ember-modules-api-polyfill-reexport`, () => {
   matches(
+    `export { default } from '@ember/component';`,
+    `export default Ember.Component;`
+  );
+
+  matches(
     `export { default as Component } from '@ember/component';`,
     `export var Component = Ember.Component;`
   );


### PR DESCRIPTION
refs https://github.com/ember-cli/ember-cli/issues/7420
follow up of #31 

This allows to `export { default } from "..."`.

