### PR TITLE
Fail on wildcard imports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,6 +85,9 @@ module.exports = function(babel) {
               specifier.type !== 'ImportDefaultSpecifier' &&
               specifier.type !== 'ImportSpecifier'
             ) {
+              if (specifier.type === 'ImportNamespaceSpecifier') {
+                throw new Error(`Using \`import * as ${specifier.local} from '${importPath}'\` is not supported.`);
+              }
               return;
             }
 

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -132,6 +132,16 @@ describe(`ember-modules-api-polyfill-reexport`, () => {
     `export var foo = 42;`
   );
 
+  it(`throws an error for wildcard imports`, assert => {
+    let input = `import * as debug from '@ember/debug';`;
+
+    assert.throws(() => {
+      transform(input, [
+        [Plugin],
+      ]);
+    }, 'Using `import * as debug from \'@ember/debug\'` is not supported');
+  });
+
   it(`throws an error for wildcard exports`, assert => {
     let input = `export * from '@ember/object/computed';`;
 


### PR DESCRIPTION
Some people are trying to use namespace imports and failing.

I tried to implement it, but the techniques used for a symbol
replacement does not seem to work for accessors. Thus, failing to let
people know this is not supported.

Fixes https://github.com/emberjs/ember.js/issues/16139