### PR TITLE
remove `import 'ember';` instead of error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,14 +52,19 @@ module.exports = function(babel) {
             throw new Error(`Unexpected non-default import from 'ember'`);
           });
 
-          let local = specifierPath.node.local;
-          if (local.name !== 'Ember') {
-            replacements.push([
-              local.name,
-              'Ember',
-            ]);
+          if (specifierPath) {
+            let local = specifierPath.node.local;
+            if (local.name !== 'Ember') {
+              replacements.push([
+                local.name,
+                'Ember',
+              ]);
+            }
+            removals.push(specifierPath);
+          } else {
+            // import 'ember';
+            path.remove();
           }
-          removals.push(specifierPath);
         }
 
         // This is the mapping to use for the import statement

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -216,6 +216,10 @@ describe(`import from 'ember'`, () => {
     `var _x = Ember;`
   );
   matches(
+    `import 'ember';`,
+    ``
+  );
+  matches(
     `import './foo';`,
     `import './foo';`
   );


### PR DESCRIPTION
Rollup may generate code like this while flattening modules. Although not ideal, since it's valid code, we should probably handle it and just remove it.