### PR TITLE
fix import-then-export case

### DIFF
--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -171,6 +171,27 @@ describe(`unknown imports from known module`, () => {
   });
 });
 
+describe(`import then export`, () => {
+  matches(
+    `import { capitalize } from '@ember/string';
+export { capitalize };`,
+    `var capitalize = Ember.String.capitalize;
+
+export { capitalize };`
+  );
+  matches(
+    `import { capitalize, camelize } from '@ember/string';
+    camelize("a thing");
+    capitalize("another thing");
+    export { capitalize };`,
+    `var capitalize = Ember.String.capitalize;
+
+Ember.String.camelize("a thing");
+capitalize("another thing");
+export { capitalize };`
+  );
+});
+
 describe('options', () => {
   describe('blacklist', () => {
     it(`allows blacklisting import paths`, assert => {


### PR DESCRIPTION
This fixes #33.

I opted to do a less-invasive change that only adjusts the behavior for the known-bad case of a local name that is being used as an ExportSpecifier.

Arguably, we should make more extensive changes, because it's not really safe to construct identifiers (or call `path.scope.rename`) with names like `Ember.String` (which is not a valid Javascript identifier, it needs to be represented as a MemberExpression). But the obvious way to fix this (always emit a variable declaration) involves accepting slightly less pithy output, and the better way to fix this (examining every usage site to decide whether it can accept a MemberExpression) would add a lot of complexity.