### PR TITLE
Drop Node 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - '6'
   - '8'
+  - '10'
 
 cache: yarn
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - '4'
   - '6'
   - '7'
   - '8'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 
 node_js:
   - '6'
-  - '7'
   - '8'
 
 cache: yarn

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "url": "https://github.com/ember-cli/babel-plugin-ember-modules-api-polyfill/issues"
   },
   "homepage": "https://github.com/ember-cli/babel-plugin-ember-modules-api-polyfill#readme",
+  "engines": {
+    "node": "6.* || 8.* || >= 10.*"
+  },
   "changelog": {
     "repo": "ember-cli/babel-plugin-ember-modules-api-polyfill",
     "labels": {


### PR DESCRIPTION
... because Node 4 is no longer maintained by the Node.js team and several dependency updates are blocked because we still support Node 4.

This PR will require a new major version release.