### PR TITLE
Add failing test for invalid identifier rewriting.

### DIFF
--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -23,6 +23,15 @@ function transform7(source, _plugins) {
   return result.code;
 }
 
+function transformWithPresetEnv(source) {
+  let result = babel7.transformSync(source, {
+    plugins: [[Plugin]],
+    presets: [['@babel/preset-env', { targets: { ie: '8' }, modules: false }]],
+  });
+
+  return result.code;
+}
+
 function matches(source, expected, only) {
   (only ? it.only : it)(`${source}`, () => {
     let actual = transform(source);
@@ -244,4 +253,17 @@ describe(`import from 'ember'`, () => {
 describe(`import without specifier is removed`, () => {
   matches(`import 'ember';`, ``);
   matches(`import '@ember/component';`, ``);
+});
+
+describe('when used with @babel/preset-env', () => {
+  it('generally works', () => {
+    let source = `
+      import Application from '@ember/application';
+
+      export default Application.extend({});
+    `;
+    let actual = transformWithPresetEnv(source);
+
+    expect(actual).toEqual(`export default Ember.Application.extend({});`);
+  });
 });


### PR DESCRIPTION
This reproduces the errors being reported (e.g. https://github.com/ember-cli/babel-plugin-ember-modules-api-polyfill/issues/64) that are ultimately caused by this libraries mutation of `Identifier` nodes to include things like `Ember.Application` (which is fundamentally not a valid identifier value, it is a `MemberExpression`).

Fails with the following:

```
  ● when used with @babel/preset-env › generally works

    expect(received).toEqual(expected) // deep equality

    - Expected
    + Received

    -
    - export default Ember.Application.extend({
    -   // stuff here
    + export default _EmberApplication.extend({// stuff here
      });

      267 |     let actual = transformWithPresetEnv(source);
      268 |
    > 269 |     expect(actual).toEqual(`
          |                    ^
      270 | export default Ember.Application.extend({
      271 |   // stuff here
      272 | });`);
```