### PR TITLE
Ensure identifiers are properly re-written.

### DIFF
--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -23,6 +23,15 @@ function transform7(source, _plugins) {
   return result.code;
 }
 
+function transformWithPresetEnv(source) {
+  let result = babel7.transformSync(source, {
+    plugins: [[Plugin]],
+    presets: [['@babel/preset-env', { targets: { ie: '8' }, modules: false }]],
+  });
+
+  return result.code;
+}
+
 function matches(source, expected, only) {
   (only ? it.only : it)(`${source}`, () => {
     let actual = transform(source);
@@ -244,4 +253,17 @@ describe(`import from 'ember'`, () => {
 describe(`import without specifier is removed`, () => {
   matches(`import 'ember';`, ``);
   matches(`import '@ember/component';`, ``);
+});
+
+describe('when used with @babel/preset-env', () => {
+  it('generally works', () => {
+    let source = `
+      import Application from '@ember/application';
+
+      export default Application.extend({});
+    `;
+    let actual = transformWithPresetEnv(source);
+
+    expect(actual).toEqual(`export default Ember.Application.extend({});`);
+  });
 });


### PR DESCRIPTION
The code previously took an identifier and replaced it's `name` value with one that included a string like `Ember.Foo`. This is completely invalid (a string like `Ember.Foo` is actually a MemberExpression), but we got away with it because for the most part Babel happily printed **whatever** value you give it in that spot.

Unfortunately, this happy mistake bit us fairly severely due to Babel introducing new plugins that run as part of `@babel/preset-env` (e.g. to make sure that all identifiers would work properly on IE9).

This commit changes from doing a `path.scope.rename(importName, globalPathString)` to properly replacing the identifier with a member expression.

This PR includes the failing test added in #108 (see that PR to confirm the failure mode), and ensures that it passes.

Fixes #64
Closes #108

