### PR TITLE
Properly transpile `(emberImportedThing as any)()`

### DIFF
--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -308,4 +308,46 @@ describe('when used with typescript', () => {
 
     expect(actual).toEqual(``);
   });
+
+  it('works when type casting', () => {
+    let source = `
+      import { addObserver } from '@ember/object/observers';
+      (addObserver as any)();
+   `;
+
+    let actual = transform7(source, [
+      '@babel/plugin-transform-typescript',
+      Plugin,
+    ]);
+
+    expect(actual).toEqual(`Ember.addObserver();`);
+  });
+
+  it('works for type assertions', () => {
+    let source = `
+      import { addObserver } from '@ember/object/observers';
+      <foo>addObserver();
+   `;
+
+    let actual = transform7(source, [
+      '@babel/plugin-transform-typescript',
+      Plugin,
+    ]);
+
+    expect(actual).toEqual(`Ember.addObserver();`);
+  });
+
+  it('works for non-null expression', () => {
+    let source = `
+      import { addObserver } from '@ember/object/observers';
+      addObserver!();
+   `;
+
+    let actual = transform7(source, [
+      '@babel/plugin-transform-typescript',
+      Plugin,
+    ]);
+
+    expect(actual).toEqual(`Ember.addObserver();`);
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,14 @@ function isBlacklisted(blacklist, importPath, exportName) {
 module.exports = function (babel) {
   const t = babel.types;
 
-  const isTypescriptNode = (node) => node.type.startsWith('TS');
+  const TSTypesRequiringModification = [
+    'TSAsExpression',
+    'TSTypeAssertion',
+    'TSNonNullExpression',
+  ];
+  const isTypescriptNode = (node) =>
+    node.type.startsWith('TS') &&
+    !TSTypesRequiringModification.includes(node.type);
 
   const GLOBALS_MAP = new Map();
 


### PR DESCRIPTION
The prior fix for TypeScript support avoids modifying any node who's parent node's type starts with `TS`. This fixed a large number of scenarios where an identifier _happened_ to be both a type and a value.

Unfortunately, there are some cases where the parent node is a `TS*` node but the node still needs to be transpiled to use the Ember global paths. For example:

```ts
import { addObserver } from '@ember/object/observers';
(addObserver as any)();
```

In this the parent node of that `addObserver` reference is a `TSAsExpression`, but we **do** need to transpile it to `Ember.addObserver`.

And:

```ts
import { addObserver } from '@ember/object/observers';
addObserver!();
```

In this the parent node of that `addObserver` reference is a `TSNonNullExpression`, but we **do** need to transpile it to `Ember.addObserver`.  

After reviewing the `@babel/plugin-transform-typescript` implementation ([see here](https://github.com/babel/babel/blob/v7.10.0/packages/babel-plugin-transform-typescript/src/index.js)) it seems that all of the other `TS*` style node types are directly removed (e.g. `path.remove()`).

Related to https://github.com/babel/ember-cli-babel/issues/341