### PR TITLE
Ensure generated global `MemberExpressions` are not shared

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,8 +25,6 @@ module.exports = function (babel) {
     node.type.startsWith('TS') &&
     !TSTypesRequiringModification.includes(node.type);
 
-  const GLOBALS_MAP = new Map();
-
   // Flips the ember-rfc176-data mapping into an 'import' indexed object, that exposes the
   // default import as well as named imports, e.g. import {foo} from 'bar'
   const reverseMapping = {};
@@ -43,28 +41,23 @@ module.exports = function (babel) {
   });
 
   function getMemberExpressionFor(global) {
-    let memberExpression = GLOBALS_MAP.get(global);
-    if (memberExpression === undefined) {
-      let parts = global.split('.');
+    let parts = global.split('.');
 
-      let object = parts.shift();
+    let object = parts.shift();
+    let property = parts.shift();
+
+    let memberExpression = t.MemberExpression(
+      t.identifier(object),
+      t.identifier(property)
+    );
+
+    while (parts.length > 0) {
       let property = parts.shift();
 
       memberExpression = t.MemberExpression(
-        t.identifier(object),
+        memberExpression,
         t.identifier(property)
       );
-
-      while (parts.length > 0) {
-        let property = parts.shift();
-
-        memberExpression = t.MemberExpression(
-          memberExpression,
-          t.identifier(property)
-        );
-      }
-
-      GLOBALS_MAP.set(global, memberExpression);
     }
 
     return memberExpression;


### PR DESCRIPTION
The original fix in b63bb6e attempted to cache the generated member expressions, so that we didn't do duplicated work for each reference to a given global. Unfortunately, this optimization failed to take into consideration that most babel plugins work by directly mutating the node in question. In practice what that meant was that once _any_ usage of a given global was needed to be transformed (e.g. say you had `computed(...args, function(){})` and are transpiling for IE11), then all usages of that global would be mutated.

A more concrete example.

```js
// input
import { computed } from '@ember/object';

function specialComputed(dependentKeys) {
  return computed(...dependentKeys, function() {});
}

function otherLessSpecialComputed() {
  return computed('stuff', 'hard', 'coded', function() {});
}
```

In this example, the first method (`specialComputed`) needs to be transpiled to something akin to (most of the changes here are from `@babel/plugin-transform-spread`):

```js
function specialComputed(dependentKeys) {
  return Ember.computed.apply(Ember, dependentKeys.concat([function() {}]));
}
```

Unfortunately, since the generated `MemberExpression` for
`Ember.computed` is shared, this forced the other `computed` usage to be
transpiled to:

```js
function otherLessSpecialComputed() {
  return Ember.computed.apply('stuff', 'hard', 'coded', function() {});
}
```

Which is clearly, **totally** invalid. 🤦