### PR TITLE
Make ensureImport lazy

### DIFF
--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -253,7 +253,7 @@ describe('options', () => {
     it(`adds the ember import when used in sub-modules`, () => {
       let input = `import Component from '@ember/component';export default class extends Component {}`;
       let actual = transform(input, [[Plugin, { useEmberModule: true }]]);
-      let expected = `import _Ember from 'ember';\nexport default class extends _Ember.Component {}`;
+      let expected = `import _ember from 'ember';\nexport default class extends _ember.Component {}`;
 
       expect(actual).toEqual(expected);
     });


### PR DESCRIPTION
Makes the logic for ensuring the Ember import lazy. This allows it to
handle cases where a different transform has also added the Ember import
already, and so it can use it lazily. Also makes the logic generalized
(in case we ever need to import from a different module in the future).